### PR TITLE
Replacing LD_LIBRARY_PATH with DYLD_LIBRARY_PATH on mac

### DIFF
--- a/avrdude.build.bash
+++ b/avrdude.build.bash
@@ -57,8 +57,8 @@ then
 	cd ../objdir/bin/
 	mv avrdude avrdude_bin
 	cp ../../avrdude-files/avrdude .
-if [ `uname -s` == "Darwin" ]
-then
-	sed -i 's/LD_LIBRARY_PATH/DYLD_LIBRARY_PATH/g' avrdude 
-fi
+	if [ `uname -s` == "Darwin" ]
+	then
+		sed -i 's/LD_LIBRARY_PATH/DYLD_LIBRARY_PATH/g' avrdude 
+	fi
 fi


### PR DESCRIPTION
On MacOsx DYLD_LIBRARY_PATH is used instead of LD_LIBRARY_PATH. The script checks the OS and use the correct environment variable
