### PR TITLE
Added support for ArduinoISP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.bz2
 *.tar.gz
+*.zip
 objdir
 toolsdir
 *-build
@@ -9,5 +10,6 @@ binutils-2.23.2
 gcc-4.8.1
 avrdude-5.11.1
 avrdude-6.0.1
-gpio-avrdude-1138
-*.zip
+libusb-1.0.18
+libusb-compat-0.1.5
+tmp

--- a/Readme.md
+++ b/Readme.md
@@ -3,10 +3,12 @@ Note: setup has been done on partially set up development machines. If, trying t
 ### Debian requirements
 
 ```bash
-sudo apt-get install build-essential gperf bison subversion texinfo zip automake
+sudo apt-get install build-essential gperf bison subversion texinfo zip automake flex libusb-dev libusb-1.0-0-dev
 ```
 
 ### Mac OSX requirements
+
+You need to install MacPorts: https://www.macports.org/install.php. Once done, open a terminal and type:
 
 ```bash
 sudo port selfupdate
@@ -15,22 +17,32 @@ sudo port install wget +universal
 sudo port install automake +universal
 sudo port install autoconf +universal
 sudo port install gpatch +universal
+sudo port install libusb +universal
 ```
 
 ### Windows requirements
 
-[Cygwin](http://www.cygwin.com/) installed with all the development tools including 
+You need to install Cygwin: http://www.cygwin.com/. Once you have run `setup-x86.exe`, use the `Search` text field to filter and select for installation the following packages:
+
+- git
+- wget
+- unzip
 - gperf
 - bison
 - flex
-- subversion
+- make
+- patch
 - automake
 - autoconf
+- gcc-g++
 - texinfo (must be at version 4.13-4 since 5+ won't work)
+
+A note on texinfo: due to dependencies, each time you update/modify your cygwin installation (for example: you install an additional package), texinfo will be upgraded to version 5+, while you need version 4+!
+Easy solution: as soon as you've installed the additional package, re-run cygwin setup, search texinfo, triple click on "Keep" until you read version 4, then click next.
 
 ### Upstream credits
 
-Most patches come from Debian and a few from WinAVR. Thank you guys for the awesome work
+Build process ported from Debian. Most patches come from Atmel. Thank you guys for your awesome work.
 
 ### Credits
 

--- a/avrdude-files/avrdude
+++ b/avrdude-files/avrdude
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH="`dirname "$0"`/../lib/"
+exec -a "$0" "`dirname "$0"`/avrdude_bin" "$@"

--- a/avrdude-patches/30-avrdude-6.0.1-added_arduinoisp.patch
+++ b/avrdude-patches/30-avrdude-6.0.1-added_arduinoisp.patch
@@ -1,0 +1,18 @@
+--- avrdude.conf.in	2013-09-18 07:59:06.000000000 +0200
++++ avrdude.conf.in	2014-02-27 17:14:40.686503613 +0100
+@@ -751,6 +751,15 @@
+ ;
+ 
+ programmer
++  id    = "arduinoisp";
++  desc  = " ";
++  type  = "usbtiny";
++  connection_type = usb;
++  usbvid     = 0x2341;
++  usbpid     = 0x0049;
++;
++
++programmer
+   id    = "butterfly";
+   desc  = "Atmel Butterfly Development Board";
+   type  = "butterfly";

--- a/avrdude.build.bash
+++ b/avrdude.build.bash
@@ -17,6 +17,24 @@ cd objdir
 PREFIX=`pwd`
 cd -
 
+if [[ `uname -s` == CYGWIN* ]]
+then
+	cd tmp/libusb-win32-bin*
+	LIBUSB_DIR=`pwd`
+	cd ../..
+
+	CFLAGS="$CFLAGS -I$LIBUSB_DIR/include -L$LIBUSB_DIR/lib/gcc"
+	CXXFLAGS="$CXXFLAGS -I$LIBUSB_DIR/include -L$LIBUSB_DIR/lib/gcc"
+	LDFLAGS="$LDFLAGS -I$LIBUSB_DIR/include -L$LIBUSB_DIR/lib/gcc"
+fi
+
+if [ `uname -s` == "Linux" ] || [ `uname -s` == "Darwin" ]
+then
+	CFLAGS="$CFLAGS -I$PREFIX/include -I$PREFIX/include/libusb-1.0/ -L$PREFIX/lib"
+	CXXFLAGS="$CXXFLAGS -I$PREFIX/include -I$PREFIX/include/libusb-1.0/ -L$PREFIX/lib"
+	LDFLAGS="$LDFLAGS -I$PREFIX/include -I$PREFIX/include -L$PREFIX/lib"
+fi
+
 mkdir -p avrdude-build
 cd avrdude-build
 
@@ -34,3 +52,13 @@ nice -n 10 make -j $MAKE_JOBS
 
 make install
 
+if [ `uname -s` == "Linux" ] || [ `uname -s` == "Darwin" ]
+then
+	cd ../objdir/bin/
+	mv avrdude avrdude_bin
+	cp ../../avrdude-files/avrdude .
+	if [ `uname -s` == "Darwin" ]
+	then
+		sed -i 's/LD_LIBRARY_PATH/DYLD_LIBRARY_PATH/g' avrdude 
+	fi
+fi

--- a/build.all.bash
+++ b/build.all.bash
@@ -11,5 +11,7 @@ rm -rf objdir toolsdir
 ./clean.bash
 ./avr-libc.build.bash
 ./clean.bash
+./libusb.build.bash
+./clean.bash
 ./avrdude.build.bash
 ./clean.bash

--- a/clean.bash
+++ b/clean.bash
@@ -2,7 +2,7 @@
 
 rm -rf autoconf-2.64 automake-1.11.1
 
-rm -rf gcc-4.8.1 gmp-5.0.2 mpc-0.9 mpfr-3.0.0 binutils-2.23.2 avr-libc-1.8.0 avr8-headers-6.2.0.142 avrdude-6.0.1 *-build
+rm -rf gcc-4.8.1 gmp-5.0.2 mpc-0.9 mpfr-3.0.0 binutils-2.23.2 avr-libc-1.8.0 avr8-headers-6.2.0.142 avrdude-6.0.1 libusb-1.0.18 libusb-compat-0.1.5 *-build
 
 rm -rf objdir/{info,man,share}
 

--- a/libusb.build.bash
+++ b/libusb.build.bash
@@ -1,0 +1,86 @@
+#!/bin/bash -ex
+
+if [[ `uname -s` == CYGWIN* ]]
+then
+	if [[ ! -f libusb-win32-bin-1.2.6.0.zip  ]] ;
+	then
+		wget http://switch.dl.sourceforge.net/project/libusb-win32/libusb-win32-releases/1.2.6.0/libusb-win32-bin-1.2.6.0.zip
+	fi
+
+	mkdir -p tmp
+	rm -rf tmp/libusb-win32-bin*
+	cd tmp
+	unzip ../libusb-win32-bin-1.2.6.0.zip
+	cd libusb-win32-bin*
+	LIBUSB_DIR=`pwd`
+	cd ../..
+
+	mkdir -p $PREFIX/bin
+	cp $LIBUSB_DIR/bin/x86/libusb0_x86.dll $PREFIX/bin/libusb0.dll
+fi
+
+if [ `uname -s` == "Linux" ] || [ `uname -s` == "Darwin" ]
+then
+	if [[ ! -f libusb-1.0.18.tar.bz2  ]] ;
+	then
+		wget http://switch.dl.sourceforge.net/project/libusb/libusb-1.0/libusb-1.0.18/libusb-1.0.18.tar.bz2
+	fi
+
+	tar xfjv libusb-1.0.18.tar.bz2
+
+	mkdir -p objdir
+	cd objdir
+	PREFIX=`pwd`
+	cd -
+
+	mkdir -p libusb-1.0-build
+	cd libusb-1.0-build
+
+	CONFARGS=" \
+		--prefix=$PREFIX \
+		--disable-udev \
+		--enable-static \
+		--enable-shared"
+
+	CFLAGS="-w -O2 $CFLAGS" CXXFLAGS="-w -O2 $CXXFLAGS" LDFLAGS="-s $LDFLAGS" ../libusb-1.0.18/configure $CONFARGS
+
+	if [ -z "$MAKE_JOBS" ]; then
+		MAKE_JOBS="2"
+	fi
+
+	nice -n 10 make -j $MAKE_JOBS
+
+	make install
+
+	cd ..
+
+	if [[ ! -f libusb-compat-0.1.5.tar.bz2  ]] ;
+	then
+		wget http://switch.dl.sourceforge.net/project/libusb/libusb-compat-0.1/libusb-compat-0.1.5/libusb-compat-0.1.5.tar.bz2
+	fi
+
+	tar xfjv libusb-compat-0.1.5.tar.bz2
+
+	mkdir -p objdir
+	cd objdir
+	PREFIX=`pwd`
+	cd -
+
+	mkdir -p libusb-0.1-build
+	cd libusb-0.1-build
+
+	CONFARGS=" \
+		--prefix=$PREFIX \
+		--enable-static \
+		--enable-shared"
+
+	PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig" CFLAGS="-w -O2 $CFLAGS" CXXFLAGS="-w -O2 $CXXFLAGS" LDFLAGS="-s $LDFLAGS" ../libusb-compat-0.1.5/configure $CONFARGS
+
+	if [ -z "$MAKE_JOBS" ]; then
+		MAKE_JOBS="2"
+	fi
+
+	nice -n 10 make -j $MAKE_JOBS
+
+	make install
+fi


### PR DESCRIPTION
Added support for ArduinoISP for avrdude. The avrdude patch adds into avrdude.conf the ArduinoISP programmer with the correct VID and PID.

Created libusb.build.bash that downloads libusb sources and builds them. Libusb is required in order to use ArduinoISP with avrdude, and using a local copy of libusb removes the dependency from libraries installed on the system.

The script avrdude.build.bash now replaces avrdude with a script that launches the real binary file (avrdude_bin) with the correct environment variable for the library path.

Edited Readme.md: added some missing packages required to build avrdude on Linux.
