### PR TITLE
Add avrdude.conf patch to increase delays for ATtiny85 erasing and uploading.

### DIFF
--- a/avrdude-patches/60-avrdude-6.0.1-attiny85_delay_increase.patch
+++ b/avrdude-patches/60-avrdude-6.0.1-attiny85_delay_increase.patch
@@ -1,0 +1,31 @@
+--- avrdude.conf.in	2015-04-02 23:54:05.862556159 +0000
++++ avrdude.conf.in	2015-04-03 00:07:02.156406668 +0000
+@@ -9234,7 +9234,7 @@
+      avr910_devcode   = 0x20;
+      signature        = 0x1e 0x93 0x0b;
+      reset            = io;
+-     chip_erase_delay = 4500;
++     chip_erase_delay = 400000;
+ 
+      pgm_enable       = "1 0 1 0  1 1 0 0    0 1 0 1  0 0 1 1",
+                         "x x x x  x x x x    x x x x  x x x x";
+@@ -9300,7 +9300,7 @@
+ 			  "  x   x   x   x      x   x   x   x";
+ 
+ 	mode		= 0x41;
+-	delay		= 6;
++	delay		= 12;
+ 	blocksize	= 4;
+ 	readsize	= 256;
+        ;
+@@ -9309,8 +9309,8 @@
+          size            = 8192;
+          page_size       = 64;
+          num_pages       = 128;
+-         min_write_delay = 4500;
+-         max_write_delay = 4500;
++         min_write_delay = 30000;
++         max_write_delay = 30000;
+          readback_p1     = 0xff;
+          readback_p2     = 0xff;
+          read_lo         = "  0   0   1   0    0   0   0   0",


### PR DESCRIPTION
This is a pull request to increase some of the delays for the ATtiny85 in avrdude.conf that Arduino's toolchain uses.  These larger delays are necessary to program ATtiny85-based boards like the Adafruit/Arduino Gemma.  Normally Adafruit has had this change as a separate config that overwrites the stock Arduino IDE's avrdude.conf while also adding new boards (can [see here](https://learn.adafruit.com/introducing-trinket/setting-up-with-arduino-ide#step-2-updating-avrdude-dot-conf) for a little more background and the current config for the legacy 1.0.x series IDE).  However with the Arduino Gemma coming soon and being built on the Adafruit Gemma board it likely makes sense to push these changes back upstream.

The changes are only to the ATtiny85 part of the avrdude configuration and just increase some delays so they should be relatively low risk to integrate.  I tested the changes by checking that a full toolchain build succeeds and the avrdude.conf.in file is modified as expected by this patch.  Let me know if you have any questions or would like to change anything in this pull, thanks!