### PR TITLE
Make use of MAKE_JOBS

### DIFF
--- a/avr-libc.build.bash
+++ b/avr-libc.build.bash
@@ -80,5 +80,5 @@ fi
 
 PATH=$PREFIX/bin:$PATH nice -n 10 make -j $MAKE_JOBS
 
-PATH=$PREFIX/bin:$PATH make install
+PATH=$PREFIX/bin:$PATH make install -j $MAKE_JOBS
 

--- a/avrdude.build.bash
+++ b/avrdude.build.bash
@@ -97,7 +97,7 @@ fi
 
 nice -n 10 make -j $MAKE_JOBS
 
-make install
+make install -j $MAKE_JOBS
 
 if [ `uname -s` == "Linux" ] || [ `uname -s` == "Darwin" ]
 then

--- a/binutils.build.bash
+++ b/binutils.build.bash
@@ -73,5 +73,5 @@ fi
 nice -n 10 make -j $MAKE_JOBS configure-host
 nice -n 10 make -j $MAKE_JOBS all
 
-make install
+make install -j $MAKE_JOBS
 

--- a/build.all.bash
+++ b/build.all.bash
@@ -17,20 +17,24 @@
 
 rm -rf toolsdir avr avrdude-6.1
 
+if [[ `nproc` > "2" ]]; then
+    JOBS=$((`nproc`+1))
+fi
+
 ./clean.bash
-./tools.bash
+MAKE_JOBS="$JOBS" ./tools.bash
 ./clean.bash
 
 rm -rf objdir*
 
 ./clean.bash
-./binutils.build.bash
+MAKE_JOBS="$JOBS" ./binutils.build.bash
 ./clean.bash
-./gcc.build.bash
+MAKE_JOBS="$JOBS" ./gcc.build.bash
 ./clean.bash
-./avr-libc.build.bash
+MAKE_JOBS="$JOBS" ./avr-libc.build.bash
 ./clean.bash
-./gdb.build.bash
+MAKE_JOBS="$JOBS" ./gdb.build.bash
 ./clean.bash
 
 if [ -z "$EXECUTABLE_FIND_FILTER" ]; then
@@ -51,9 +55,9 @@ mv objdir avr
 mkdir objdir
 
 ./clean.bash
-./libusb.build.bash
+MAKE_JOBS="$JOBS" ./libusb.build.bash
 ./clean.bash
-./avrdude.build.bash
+MAKE_JOBS="$JOBS" ./avrdude.build.bash
 ./clean.bash
 
 mv objdir avrdude-6.1

--- a/gcc.build.bash
+++ b/gcc.build.bash
@@ -108,5 +108,5 @@ fi
 
 nice -n 10 make -j $MAKE_JOBS
 
-make install
+make install -j $MAKE_JOBS
 

--- a/gdb.build.bash
+++ b/gdb.build.bash
@@ -62,5 +62,5 @@ fi
 
 nice -n 10 make -j $MAKE_JOBS
 
-make install
+make install -j $MAKE_JOBS
 

--- a/libusb.build.bash
+++ b/libusb.build.bash
@@ -61,7 +61,7 @@ then
 
 	nice -n 10 make -j 1
 
-	make install
+	make install -j $MAKE_JOBS
 
 	cd ..
 
@@ -84,5 +84,5 @@ then
 
 	nice -n 10 make -j 1
 
-	make install
+	make install -j $MAKE_JOBS
 fi

--- a/tools.bash
+++ b/tools.bash
@@ -43,7 +43,7 @@ CONFARGS="--prefix=$TOOLS_PATH"
 
 nice -n 10 make -j $MAKE_JOBS
 
-make install
+make install -j $MAKE_JOBS
 
 cd -
 
@@ -64,7 +64,7 @@ CONFARGS="--prefix=$TOOLS_PATH"
 
 nice -n 10 make -j $MAKE_JOBS
 
-make install
+make install -j $MAKE_JOBS
 
 cd -
 


### PR DESCRIPTION
This builds upon the use of MAKE_JOBS by adding it to the 'make install's.
And adds the use of it to build.all.bash to help speed make's up.