### PR TITLE
Changed URL for avr-libc-1.8.0.tar.bz2

### DIFF
--- a/avr-libc.build.bash
+++ b/avr-libc.build.bash
@@ -29,7 +29,7 @@ export PATH="$TOOLS_BIN_PATH:$PATH"
 
 if [[ ! -f avr-libc-1.8.0.tar.bz2 ]] ;
 then
-	wget http://download.savannah.gnu.org/releases/avr-libc/avr-libc-1.8.0.tar.bz2
+	wget http://download.savannah.gnu.org/releases/avr-libc/old-releases/avr-libc-1.8.0.tar.bz2
 fi
 
 tar xfv avr-libc-1.8.0.tar.bz2


### PR DESCRIPTION
This addresses the missing dependency component of issue #31.  My build on the latest branch now fails at a later stage.