### PR TITLE
Amend build scripts for FreeBSD Compatibility; use gmake instead of m…

### DIFF
--- a/avr-libc.build.bash
+++ b/avr-libc.build.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 # Copyright (c) 2014-2015 Arduino LLC
 #
 # This program is free software; you can redistribute it and/or
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+set -ex
+
 if [[ ! -d toolsdir  ]] ;
 then
 	echo "You must first build the tools: run build_tools.bash"
@@ -26,10 +28,16 @@ TOOLS_BIN_PATH=`pwd`
 cd -
 
 export PATH="$TOOLS_BIN_PATH:$PATH"
+MAKE=make
 
 if [[ ! -f avr-libc.tar.bz2 ]] ;
 then
 	wget http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.5.3/avr-libc.tar.bz2
+fi
+
+if [ `uname -s` == "FreeBSD" ] ;
+then
+	MAKE=gmake
 fi
 
 if [[ $OS == "Msys" || $OS == "Cygwin" ]] ; then
@@ -88,7 +96,7 @@ if [ -z "$MAKE_JOBS" ]; then
 	MAKE_JOBS="2"
 fi
 
-PATH=$PREFIX/bin:$PATH nice -n 10 make -j $MAKE_JOBS
+PATH=$PREFIX/bin:$PATH nice -n 10 $MAKE -j $MAKE_JOBS
 
-PATH=$PREFIX/bin:$PATH make install
+PATH=$PREFIX/bin:$PATH $MAKE install
 

--- a/binutils.build.bash
+++ b/binutils.build.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 # Copyright (c) 2014-2015 Arduino LLC
 #
 # This program is free software; you can redistribute it and/or
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+set -ex
+
 if [[ ! -d toolsdir  ]] ;
 then
 	echo "You must first build the tools: run build_tools.bash"
@@ -26,6 +28,12 @@ TOOLS_BIN_PATH=`pwd`
 cd -
 
 export PATH="$TOOLS_BIN_PATH:$PATH"
+MAKE=make
+
+if [ `uname s` == "FreeBSD" ] ;
+then
+	MAKE=gmake
+fi
 
 if [[ ! -f avr-binutils.tar.bz2  ]] ;
 then
@@ -67,8 +75,8 @@ if [ -z "$MAKE_JOBS" ]; then
 	MAKE_JOBS="2"
 fi
 
-nice -n 10 make -j $MAKE_JOBS configure-host
-nice -n 10 make -j $MAKE_JOBS all
+nice -n 10 $MAKE -j $MAKE_JOBS configure-host
+nice -n 10 $MAKE -j $MAKE_JOBS all
 
-make install
+$MAKE install
 

--- a/gcc.build.bash
+++ b/gcc.build.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 # Copyright (c) 2014-2015 Arduino LLC
 #
 # This program is free software; you can redistribute it and/or
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+set  -ex
+
 if [[ ! -d toolsdir  ]] ;
 then
 	echo "You must first build the tools: run build_tools.bash"
@@ -26,6 +28,12 @@ TOOLS_BIN_PATH=`pwd`
 cd -
 
 export PATH="$TOOLS_BIN_PATH:$PATH"
+MAKE=make
+
+if [ `uname -s` == "FreeBSD" ] ;
+then
+	MAKE=gmake
+fi
 
 if [[ ! -f gmp-5.0.2.tar.bz2  ]] ;
 then
@@ -110,7 +118,7 @@ if [ -z "$MAKE_JOBS" ]; then
 	MAKE_JOBS="2"
 fi
 
-nice -n 10 make -j $MAKE_JOBS
+nice -n 10 $MAKE -j $MAKE_JOBS
 
-make install
+$MAKE install
 

--- a/gdb.build.bash
+++ b/gdb.build.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 # Copyright (c) 2014-2015 Arduino LLC
 #
 # This program is free software; you can redistribute it and/or
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+set -ex
+
 if [[ ! -d toolsdir  ]] ;
 then
 	echo "You must first build the tools: run build_tools.bash"
@@ -26,7 +28,13 @@ TOOLS_BIN_PATH=`pwd`
 cd -
 
 export PATH="$TOOLS_BIN_PATH:$PATH"
+MAKE=make
 
+if [ `uname -s` == "FreeBSD" ] ;
+then
+	MAKE=gmake
+fi
+ 
 if [[ ! -f avr-gdb.tar.bz2  ]] ;
 then
 	wget http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.5.3/avr-gdb.tar.bz2
@@ -63,7 +71,7 @@ if [ -z "$MAKE_JOBS" ]; then
 	MAKE_JOBS="2"
 fi
 
-nice -n 10 make -j $MAKE_JOBS
+nice -n 10 $MAKE -j $MAKE_JOBS
 
-make install
+$MAKE install
 

--- a/package-avr-gcc.bash
+++ b/package-avr-gcc.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 # Copyright (c) 2014-2016 Arduino LLC
 #
 # This program is free software; you can redistribute it and/or
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+set -ex
 
 OUTPUT_VERSION=4.9.2-atmel3.5.3-arduino2
 
@@ -59,6 +61,10 @@ elif [[ $OS == "Darwin" ]] ; then
   export CC="gcc -arch i386 -mmacosx-version-min=10.5"
   export CXX="g++ -arch i386 -mmacosx-version-min=10.5"
   OUTPUT_TAG=i386-apple-darwin11
+
+elif [[ $OS == "FreeBSD" ]] ; then
+
+  export MACHINE=`uname -m` 
 
 else
 

--- a/tools.bash
+++ b/tools.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 # Copyright (c) 2014-2015 Arduino LLC
 #
 # This program is free software; you can redistribute it and/or
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+set -ex
+
 mkdir -p toolsdir/bin
 cd toolsdir
 TOOLS_PATH=`pwd`
@@ -23,6 +25,12 @@ TOOLS_BIN_PATH=`pwd`
 cd ../../
 
 export PATH="$TOOLS_BIN_PATH:$PATH"
+MAKE=make
+
+if [ `uname -s` == "FreeBSD" ] ;
+then
+	MAKE=gmake
+fi
 
 if [ -z "$MAKE_JOBS" ]; then
 	MAKE_JOBS="2"
@@ -41,9 +49,9 @@ CONFARGS="--prefix=$TOOLS_PATH"
 
 ./configure $CONFARGS
 
-nice -n 10 make -j $MAKE_JOBS
+nice -n 10 $MAKE -j $MAKE_JOBS
 
-make install
+$MAKE install
 
 cd -
 
@@ -62,9 +70,9 @@ CONFARGS="--prefix=$TOOLS_PATH"
 
 ./configure $CONFARGS
 
-nice -n 10 make -j $MAKE_JOBS
+nice -n 10 $MAKE -j $MAKE_JOBS
 
-make install
+$MAKE install
 
 cd -
 


### PR DESCRIPTION
…ake, use /usr/bin/env bash for shebang line, and set -ex immediately

For what it's worth, I actually snagged a Linux machine to test this one on. =) I know it's not quite as convenient as using -ex in the shebang, but perhaps this is a decent compromise? (set -ex as first command to execute -- achieves exact same effect, but overall more portable)
