### PR TITLE
Make build process easier to retarget to new Atmel release

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,15 +5,34 @@ This is the AVR Toolchain used in the [Arduino IDE](http://arduino.cc/).
 As soon as Atmel [ships a newer toolchain](http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/), we pull the source code, **patch it** with some user contributed patches and deliver it with the [Arduino IDE](http://arduino.cc/).
 Therefore, the resulting binaries may differ significantly from Atmel's. And you should start blaming us if things are not working as expected :)
 
-Latest toolchain available is based on Atmel 3.5.2 version. It contains:
+### Configuring
+
+Edit the `build.conf` file, currently the only thing worth changing is `AVR_VERSION` on the first line to match whatever the [latest version is](http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/).
+
+At time of writing, the latest toolchain available is based on Atmel 3.5.4 version. It contains:
  - binutils-2.26
  - gcc-4.9.2
  - avr-libc-2.0.0
  - gdb-7.8
-
+ 
 ### Building
 
 Setup has been done on partially set up development machines. If, trying to compile on your machine, you find any package missing from the following list, please open an issue at once! We all can't afford wasting time on setup :)
+
+To just build, after getting the requirements...
+```bash
+./tools.bash
+./binutils.build.bash
+./gcc.build.bash
+./libc.build.bash
+./gdb.build.bash
+```
+after a successful compile the binaries etc will be found in `objdir`
+
+To package, after getting the requirements...
+```bash
+./package-avr-gcc.bash
+```
 
 #### Debian requirements
 

--- a/avr-libc.build.bash
+++ b/avr-libc.build.bash
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+source build.conf
+
 if [[ ! -d toolsdir  ]] ;
 then
 	echo "You must first build the tools: run build_tools.bash"
@@ -29,7 +31,7 @@ export PATH="$TOOLS_BIN_PATH:$PATH"
 
 if [[ ! -f avr-libc.tar.bz2 ]] ;
 then
-	wget http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.5.3/avr-libc.tar.bz2
+	wget $AVR_SOURCES/avr-libc.tar.bz2
 fi
 
 if [[ $OS == "Msys" || $OS == "Cygwin" ]] ; then
@@ -53,7 +55,7 @@ cd -
 
 if [[ ! -f avr8-headers.zip ]] ;
 then
-	wget http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.5.3/avr8-headers.zip
+	wget $AVR_SOURCES/avr8-headers.zip
 fi
 
 unzip avr8-headers.zip -d avr8-headers

--- a/binutils.build.bash
+++ b/binutils.build.bash
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+source build.conf
+
 if [[ ! -d toolsdir  ]] ;
 then
 	echo "You must first build the tools: run build_tools.bash"
@@ -29,7 +31,7 @@ export PATH="$TOOLS_BIN_PATH:$PATH"
 
 if [[ ! -f avr-binutils.tar.bz2  ]] ;
 then
-	wget http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.5.3/avr-binutils.tar.bz2
+	wget $AVR_SOURCES/avr-binutils.tar.bz2
 fi
 tar xfv avr-binutils.tar.bz2
 

--- a/build.conf
+++ b/build.conf
@@ -1,0 +1,58 @@
+AVR_VERSION=3.5.4
+BUILD_NUMBER=arduino2
+
+AVR_SOURCES="http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/${AVR_VERSION}"
+GNU_SOURCES="http://mirror.switch.ch/ftp/mirror/gnu"
+MPC_SOURCES="http://www.multiprecision.org/mpc/download"
+
+# The following version numbers are by default parsed out of the SOURCES.README
+# in the Atmel distribution, you can override here if you want (or if it breaks)
+
+# GCC_VERSION=4.9.2
+# AUTOCONF_VERSION=2.64
+# AUTOMAKE_VERSION=1.11.1
+# GMP_VERSION=5.0.2
+# MPFR_VERSION=3.0.0
+# MPC_VERSION=0.9
+
+# With any luck, you don't need to edit the below
+################################################################################
+
+# Defaut the versions of gmp/mpfr/mpc to those specified in the SOURCES.README
+SOURCES_README="$(wget -O - http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/${AVR_VERSION}/SOURCES.README 2>/dev/null)"
+[ -z "$GCC_VERSION"       ] && GCC_VERSION="$(echo "$SOURCES_README" | grep -Po "GCC\s+([0-9]+\.)+[0-9]+" | sed -r 's/GCC\s//')"
+[ -z "$AUTOMAKE_VERSION"  ] && AUTOMAKE_VERSION="$(echo "$SOURCES_README" | grep -Po "automake-([0-9]+\.)+[0-9]+" | sed -r 's/[^-]+-//')"
+[ -z "$AUTOCONF_VERSION"  ] && AUTOCONF_VERSION="$(echo "$SOURCES_README" | grep -Po "autoconf-([0-9]+\.)+[0-9]+" | sed -r 's/[^-]+-//')"
+[ -z "$GMP_VERSION"  ] && GMP_VERSION="$(echo "$SOURCES_README" | grep -Po "gmp-([0-9]+\.)+[0-9]+" | sed -r 's/[^-]+-//')"
+[ -z "$MPFR_VERSION" ] && MPFR_VERSION="$(echo "$SOURCES_README" | grep -Po "mpfr-([0-9]+\.)+[0-9]+" | sed -r 's/[^-]+-//')"
+[ -z "$MPC_VERSION"  ] && MPC_VERSION="$(echo "$SOURCES_README" | grep -Po "mpc-([0-9]+\.)+[0-9]+" | sed -r 's/[^-]+-//')"
+
+# Build the URLs from which to grab the archives for those components
+AUTOCONF_SOURCE="${GNU_SOURCES}/autoconf/autoconf-${AUTOCONF_VERSION}.tar.bz2"
+AUTOMAKE_SOURCE="${GNU_SOURCES}/automake/automake-${AUTOMAKE_VERSION}.tar.bz2"
+GMP_SOURCE="${GNU_SOURCES}/gmp/gmp-${GMP_VERSION}.tar.bz2"
+MPFR_SOURCE="${GNU_SOURCES}/mpfr/mpfr-${MPFR_VERSION}.tar.bz2"
+MPC_SOURCE="${MPC_SOURCES}/mpc-${MPC_VERSION}.tar.gz"
+
+# For debugging, spit it all out
+cat <<EOF
+VERSIONS
+-------------------------------------------------------------------------------
+GCC:         ${GCC_VERSION}
+AVR:         ${AVR_VERSION}
+BUILD:       ${BUILD_NUMBER}
+AUTOCONF:    ${AUTOCONF_VERSION}
+AUTOMAKE:    ${AUTOMAKE_VERSION}
+GMP:         ${GMP_VERSION}
+MPFR:        ${MPFR_VERSION}
+MPC:         ${MPC_VERSION}
+
+SOURCES
+-------------------------------------------------------------------------------
+AUTOCONF:    ${AUTOCONF_SOURCE}
+AUTOMAKE:    ${AUTOMAKE_SOURCE}
+GMP:         ${GMP_SOURCE}
+MPFR:        ${MPFR_SOURCE}
+MPC:         ${MPC_SOURCE}
+AVR:         ${AVR_SOURCES}/*
+EOF

--- a/gcc.build.bash
+++ b/gcc.build.bash
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+source build.conf
+
 if [[ ! -d toolsdir  ]] ;
 then
 	echo "You must first build the tools: run build_tools.bash"
@@ -27,30 +29,30 @@ cd -
 
 export PATH="$TOOLS_BIN_PATH:$PATH"
 
-if [[ ! -f gmp-5.0.2.tar.bz2  ]] ;
+if [[ ! -f gmp-${GMP_VERSION}.tar.bz2  ]] ;
 then
-	wget http://mirror.switch.ch/ftp/mirror/gnu/gmp/gmp-5.0.2.tar.bz2
+	wget ${GMP_SOURCE}
 fi
 
-tar xfv gmp-5.0.2.tar.bz2
+tar xfv gmp-${GMP_VERSION}.tar.bz2
 
-if [[ ! -f mpfr-3.0.0.tar.bz2  ]] ;
+if [[ ! -f mpfr-${GMPFR_VERSION}.tar.bz2  ]] ;
 then
-	wget http://mirror.switch.ch/ftp/mirror/gnu/mpfr/mpfr-3.0.0.tar.bz2
+	wget ${MPFR_SOURCE}
 fi
 
-tar xfv mpfr-3.0.0.tar.bz2
+tar xfv mpfr-${MPFR_VERSION}.tar.bz2
 
-if [[ ! -f mpc-0.9.tar.gz  ]] ;
+if [[ ! -f mpc-${MPC_VERSION}.tar.gz  ]] ;
 then
-	wget http://www.multiprecision.org/mpc/download/mpc-0.9.tar.gz
+	wget ${MPC_SOURCE}
 fi
 
-tar xfv mpc-0.9.tar.gz
+tar xfv mpc-${MPC_VERSION}.tar.gz
 
 if [[ ! -f avr-gcc.tar.bz2 ]] ;
 then
-	wget http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.5.3/avr-gcc.tar.bz2
+	wget $AVR_SOURCES/avr-gcc.tar.bz2
 fi
 
 tar xfv avr-gcc.tar.bz2

--- a/gdb.build.bash
+++ b/gdb.build.bash
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+source build.conf
+
 if [[ ! -d toolsdir  ]] ;
 then
 	echo "You must first build the tools: run build_tools.bash"
@@ -29,7 +31,7 @@ export PATH="$TOOLS_BIN_PATH:$PATH"
 
 if [[ ! -f avr-gdb.tar.bz2  ]] ;
 then
-	wget http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/3.5.3/avr-gdb.tar.bz2
+	wget $AVR_SOURCES/avr-gdb.tar.bz2
 fi
 
 tar xfv avr-gdb.tar.bz2

--- a/gdb.build.bash
+++ b/gdb.build.bash
@@ -67,5 +67,7 @@ fi
 
 nice -n 10 make -j $MAKE_JOBS
 
-make install
+# New versions of gdb share the same configure/make scripts with binutils. Running make install-gdb to
+# install just the gdb binaries.
+make install-gdb
 

--- a/package-avr-gcc.bash
+++ b/package-avr-gcc.bash
@@ -15,7 +15,9 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-OUTPUT_VERSION=4.9.2-atmel3.5.3-arduino2
+source build.conf
+
+OUTPUT_VERSION=${GCC_VERSION}-atmel${AVR_VERSION}-${BUILD_NUMBER}
 
 export OS=`uname -o || uname`
 export TARGET_OS=$OS
@@ -67,8 +69,8 @@ else
 
 fi
 
-rm -rf autoconf-2.64 automake-1.11.1
-rm -rf gcc gmp-5.0.2 mpc-0.9 mpfr-3.0.0 binutils avr-libc libc avr8-headers gdb
+rm -rf autoconf-${AUTOCONF_VERSION} automake-${AUTOMAKE_VERSION}
+rm -rf gcc gmp-${GMP_VERSION} mpc-${MPC_VERSION} mpfr-${MPFR_VERSION} binutils avr-libc libc avr8-headers gdb
 rm -rf toolsdir objdir *-build
 
 ./tools.bash

--- a/tools.bash
+++ b/tools.bash
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+source build.conf
+
 mkdir -p toolsdir/bin
 cd toolsdir
 TOOLS_PATH=`pwd`
@@ -28,14 +30,14 @@ if [ -z "$MAKE_JOBS" ]; then
 	MAKE_JOBS="2"
 fi
 
-if [[ ! -f autoconf-2.64.tar.bz2  ]] ;
+if [[ ! -f autoconf-${AUTOCONF_VERSION}.tar.bz2  ]] ;
 then
-	wget http://mirror.switch.ch/ftp/mirror/gnu/autoconf/autoconf-2.64.tar.bz2
+	wget $AUTOCONF_SOURCE
 fi
 
-tar xfjv autoconf-2.64.tar.bz2
+tar xfjv autoconf-${AUTOCONF_VERSION}.tar.bz2
 
-cd autoconf-2.64
+cd autoconf-${AUTOCONF_VERSION}
 
 CONFARGS="--prefix=$TOOLS_PATH"
 
@@ -47,20 +49,25 @@ make install
 
 cd -
 
-if [[ ! -f automake-1.11.1.tar.bz2  ]] ;
+if [[ ! -f automake-${AUTOMAKE_VERSION}.tar.bz2  ]] ;
 then
-	wget http://mirror.switch.ch/ftp/mirror/gnu/automake/automake-1.11.1.tar.bz2
+	wget $AUTOMAKE_SOURCE
 fi
 
-tar xfjv automake-1.11.1.tar.bz2
+tar xfjv automake-${AUTOMAKE_VERSION}.tar.bz2
 
-cd automake-1.11.1
+cd automake-${AUTOMAKE_VERSION}
 
 ./bootstrap
 
 CONFARGS="--prefix=$TOOLS_PATH"
 
 ./configure $CONFARGS
+
+# Prevent compilation problem with docs complaining about @itemx not following @item
+cp doc/automake.texi doc/automake.texi2
+cat doc/automake.texi2 | sed -r 's/@itemx/@c @itemx/' >doc/automake.texi
+rm doc/automake.texi2
 
 nice -n 10 make -j $MAKE_JOBS
 


### PR DESCRIPTION
This pull request adds a file build.conf and various supporting changes to the build scripts.

The build.conf file allows you to specify simply the Atmel release version (`AVR_VERSION`) and that is the only change necessary to build for a new/different release from Atmel.

The version numbers of the supporting tools (autoconf...) and the gcc components not distributed by Atmel (gmp, mpfr, mpc) are automatically grepped out of the SOURCES.README in the Atmel distribution.  

The URLs to these requirements are automatically constructed, and can be configured differently in the build.conf if you need to change that to a different mirror or whatever.

Also included is a slight fix to the build for automake which was failing on my system due to incompatibilities with texinfo - probably texinfo version specified by Atmel should be included into the tools build process, but maybe there is a catch-22 there.