### PR TITLE
Update README.md and MPC source URL root

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ To package, after getting the requirements...
 #### Debian requirements
 
 ```bash
-sudo apt-get install build-essential gperf bison subversion texinfo zip automake flex libtinfo-dev pkg-config
+sudo apt-get install build-essential gperf bison subversion texinfo zip automake flex libtinfo-dev pkg-config wget
 ```
 
 #### Mac OSX requirements

--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ To just build, after getting the requirements...
 ./tools.bash
 ./binutils.build.bash
 ./gcc.build.bash
-./libc.build.bash
+./avr-libc.build.bash
 ./gdb.build.bash
 ```
 after a successful compile the binaries etc will be found in `objdir`

--- a/build.conf
+++ b/build.conf
@@ -3,7 +3,7 @@ BUILD_NUMBER=arduino2
 
 AVR_SOURCES="http://distribute.atmel.no/tools/opensource/Atmel-AVR-GNU-Toolchain/${AVR_VERSION}"
 GNU_SOURCES="http://mirror.switch.ch/ftp/mirror/gnu"
-MPC_SOURCES="http://www.multiprecision.org/mpc/download"
+MPC_SOURCES="http://www.multiprecision.org/downloads"
 
 # The following version numbers are by default parsed out of the SOURCES.README
 # in the Atmel distribution, you can override here if you want (or if it breaks)


### PR DESCRIPTION
I noticed that one of source URLs is now outdated. I've also updated the README.md with a couple of minor things.

Build demonstrated here: https://github.com/evansgp/docker-arduino-toolchain.

This is in relation to this thread: https://groups.google.com/a/arduino.cc/forum/#!topic/developers/6anSTArSFRY