### PR TITLE
Enable 'avrtiny' and 'avrxmega7' families by fixing patch format

### DIFF
--- a/avr-gcc-patches/atmel-patches-gcc.7.3.0-arduino2.patch
+++ b/avr-gcc-patches/atmel-patches-gcc.7.3.0-arduino2.patch
@@ -1559,7 +1559,7 @@ diff -ur gcc/gcc/config/avr/specs.h gcc-7.3.0-patched/gcc/config/avr/specs.h
 diff -ur gcc/gcc/config/avr/t-multilib gcc-7.3.0-patched/gcc/config/avr/t-multilib
 --- gcc/gcc/config/avr/t-multilib	2017-01-01 13:07:43.905435000 +0100
 +++ gcc-7.3.0-patched/gcc/config/avr/t-multilib	2018-11-29 16:08:58.825647392 +0100
-@@ -21,21 +21,24 @@
+@@ -21,21 +21,26 @@
  # along with GCC; see the file COPYING3.  If not see
  # <http://www.gnu.org/licenses/>.
  


### PR DESCRIPTION
When trying to use [XMegaForArduino](https://github.com/XMegaForArduino) and build example blink for **atxmega128a1u**, I've got the following errors:

```
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: cannot find crtatxmega128a1u.o: No such file or directory
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: skipping incompatible /Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/lib/libm.a when searching for -lm
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: cannot find -lm
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: skipping incompatible /Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/libgcc.a when searching for -lgcc
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: cannot find -lgcc
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: skipping incompatible /Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/lib/libm.a when searching for -lm
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: cannot find -lm
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: skipping incompatible /Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/lib/libc.a when searching for -lc
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: cannot find -lc
/Applications/Arduino.app/Contents/Java/hardware/tools/avr/bin/../lib/gcc/avr/7.3.0/../../../../avr/bin/ld: cannot find -latxmega128a1u
```

After investigation I've found the absence of 'avrxmega7' and 'avrtiny' support because of incorrect patch format.